### PR TITLE
Fixes issue when on Edit Project the Associated Cruise Control Projec…

### DIFF
--- a/src/ZBuildLights.Web/Views/Admin/EditProject.cshtml
+++ b/src/ZBuildLights.Web/Views/Admin/EditProject.cshtml
@@ -70,7 +70,8 @@
                         @for (var projectIndex = 0; projectIndex < Model.Project.CruiseProjectAssociations.Length; projectIndex++)
                         {
                             var cruiseProject = Model.Project.CruiseProjectAssociations[projectIndex];
-                            var serverDefinition = Model.CruiseServers.Single(x => x.Id.Equals(cruiseProject.ServerId));
+                            var serverDefinition = Model.CruiseServers.FirstOrDefault(x => x.Id.Equals(cruiseProject.ServerId));
+                            if (serverDefinition == null) {continue;}
                             <div class="row cruise-select-row">
                                 <div class="col-lg-6">
                                     <select class="form-control cruise-server-select" name="@string.Format("cruiseProject[{0}].Server", projectIndex)">


### PR DESCRIPTION
…ts drop down reset to remove entry. Next visit to page will YSOD due to ServerId == Guid.Empty

Scenarios results from Edit Project screen not having a way to remove an associated cruise control project. For example, setup a project with two Cruise Control projects:

![zsave](https://cloud.githubusercontent.com/assets/575746/8068397/4b70758e-0eb9-11e5-8cf8-c7ca22560dc0.PNG)

Then edit the project again and set the second entry to the default drop down entries:

![zedit](https://cloud.githubusercontent.com/assets/575746/8068410/5dbf0386-0eb9-11e5-9d3a-e851a6bb3ae5.PNG)

The Edit screen will update the second entry with the name of Guid.Empty and a Server Id of Guid.Empty. This causes the call to Single on Line 73 to fail. This fix simply allows the Edit screen to display without throwing an error but does not fix the underlying root cause data corruption to Model.Project.CruiseProjectAssociations.
